### PR TITLE
Fix make error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 all:
 	gcc -o libperson.so -Wall -g -shared -fPIC person.c
-	gcc -o hello -L. -lperson hello.c
+	gcc -o hello -L. hello.c -lperson
 
 run:
 	LD_LIBRARY_PATH=. ./hello


### PR DESCRIPTION
This commit fix:
gcc -o libperson.so -Wall -g -shared -fPIC person.c
gcc -o hello -L. -lperson hello.c
/usr/bin/ld: /tmp/cccSMPfZ.o: in function `main':
hello.c:(.text+0x22): undefined reference to `get_person'
collect2: error: ld returned 1 exit status
make: *** [Makefile:4: all] Error 1